### PR TITLE
[FEATURE] Added configuration to enabled proxying gravatar images

### DIFF
--- a/Classes/AvatarProvider/GravatarProvider.php
+++ b/Classes/AvatarProvider/GravatarProvider.php
@@ -15,6 +15,7 @@ namespace MiniFranske\Gravatar\AvatarProvider;
  */
 use TYPO3\CMS\Backend\Backend\Avatar\Image;
 use TYPO3\CMS\Backend\Backend\Avatar\AvatarProviderInterface;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -72,11 +73,19 @@ class GravatarProvider implements AvatarProviderInterface
         }
 
         $size = min(2048, $size);
-        $gravatarUrl = 'https://www.gravatar.com/avatar/' . md5(strtolower($backendUser['email'] ?: $backendUser['username'])) . '?s=' . $size . '&d=' . urlencode($fallback);
+        $md5 = md5(strtolower($backendUser['email'] ?: $backendUser['username']));
+
+        if (!empty($configuration['useProxy'])) {
+            // change to proxy url
+            $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+            $uri = (string)$uriBuilder->buildUriFromRoute('gravatar', ['md5' => $md5, 'size' => $size, 'd' => $fallback]);
+        } else {
+            $uri = 'https://www.gravatar.com/avatar/' . $md5 . '?s=' . $size . '&d=' . urlencode($fallback);
+        }
 
         $image = GeneralUtility::makeInstance(
             Image::class,
-            $gravatarUrl,
+            $uri,
             $size,
             $size
         );

--- a/Classes/Controller/ProxyController.php
+++ b/Classes/Controller/ProxyController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace MiniFranske\Gravatar\Controller;
+
+use TYPO3\CMS\Core\Http\Request;
+use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class ProxyController
+{
+
+    public function proxyAction(Request $request, Response $response)
+    {
+        $params = $request->getQueryParams();
+
+        if (!isset($params['md5'], $params['size'], $params['d'])) {
+            throw new \Exception('Missing gravatar parameters', 1470912686);
+        }
+
+        $md5 = $params['md5'];
+        $size = $params['size'];
+        $d = $params['d'];
+        $uri = 'https://www.gravatar.com/avatar/' . $md5 . '?s=' . $size . '&d=' . urlencode($d);
+
+        $headers = [];
+        if ($request->getHeaderLine('If-Modified-Since')) {
+            $headers[] = 'If-Modified-Since: ' . $request->getHeaderLine('If-Modified-Since');
+        }
+
+        $report = false;
+        // request image from gravatar
+        $result = GeneralUtility::getUrl($uri, 1, $headers, $report);
+        // Header and content are separated by an empty line
+        list($header, $body) = explode(CRLF . CRLF, $result, 2);
+
+        if ($report['http_code'] == 304) {
+            $response = $response->withStatus(304, 'Not Modified');
+        }
+
+        // Forward these response headers to the client
+        $passHeaders = [
+            'content-disposition',
+            'content-type',
+            'date',
+            'expires',
+            'last-modified',
+        ];
+        $headerArr = preg_split('/\\r|\\n/', $header, -1, PREG_SPLIT_NO_EMPTY);
+        foreach ($headerArr as $header) {
+            foreach ($passHeaders as $h) {
+                if (preg_match('/^' . $h . ':/i', $header)) {
+                    list($headerName, $headerValue) = explode(':', $header, 2);
+                    $response = $response->withAddedHeader($headerName, $headerValue);
+                }
+            }
+        }
+
+        if ($body) {
+            // response needs a stream instead of a string
+            $bodyStream = fopen('php://memory','r+');
+            fwrite($bodyStream, $body);
+            rewind($bodyStream);
+            $bodyStream = new Stream($bodyStream);
+            $response = $response->withBody($bodyStream);
+        }
+
+        return $response;
+    }
+}

--- a/Configuration/Backend/Routes.php
+++ b/Configuration/Backend/Routes.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+	'gravatar' => [
+		'path' => '/gravatar',
+		'target' => \MiniFranske\Gravatar\Controller\ProxyController::class . '::proxyAction',
+	],
+];

--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,11 @@ Gravatar is a free service for site owners, developers, and users. For more info
 
 **QuickStart:**
 
-Install extension and that's it. Gravatar support is enabled for BE users with a email address set and no avatar image.
+Install extension and that's it. Gravatar support is enabled for BE users with an email address set and no avatar image.
 
 By default Gravatar is only used when a user hasn't an avatar image linked to his account an email address set.
 But optional the email address check can be disabled so also BE users without email address set can get a
-generated images provided by Gravatar.
+generated image provided by Gravatar.
 
 
 **How to use:**
@@ -28,7 +28,7 @@ generated images provided by Gravatar.
 
 2. *Optional (by default the Gravatar service is now enabled and will be used for BE users without avatar image and with email address set):*
 
-   Set a fallback behaviour thought extensions configuration (see extension manager)
+   Set a fallback behaviour through extensions configuration (see extension manager)
 
 
 **Features:**
@@ -43,6 +43,10 @@ generated images provided by Gravatar.
   - **blank:** a transparent PNG image
 
 - Can also be used to show generated Gravatar image for BE users without email address
+
+- Proxy for Gravatar images: Instead of generating images which point to Gravatars-servers, use a proxy.
+This improves privacy a bit, because your users will not request the images directly from Gravatar. **Note**: Gravatar will still receive the hashed email addresses.
+This feature is disabled by default and can be enabled in extension configuration with `privacy.useProxy`.
 
 
 **Requirements:**

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -6,3 +6,6 @@ fallbackImageUrl =
 
 # cat=Gravatar fallback; type=boolean; label=Use Gravatar service even if email address is empty: Normally the Gravatar service is only requested when a email address is set. With this setting you can also enable is for BE users without email address. The above fallback will always be used then.
 forceProvider =
+
+# cat=Gravatar Privacy; type=boolean; label=Improve privacy by proxying the image request
+useProxy =


### PR DESCRIPTION
This improves the privacy of backend users because they will not send requests to gravatar.
It also solves issues for intranets where the users have no direct internet connection,
but the webserver can use the http-proxy configured in TYPO3

Solves #4 
